### PR TITLE
Data importing

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -182,7 +182,7 @@ def _load_dataframe(data, extension):
 
 def _read_csv_file(data, extension=None):
     try:
-        return pandas.read_csv(open(data, 'rU'), header=None, index_col=None)
+        return pandas.read_csv(open(data, 'rb'), header=None, index_col=None)
     except Exception as e:
         extension = "(" + extension + ")" if extension else ""
         raise t.ValidationError({
@@ -195,7 +195,7 @@ def _read_csv_file(data, extension=None):
 
 def _read_excel_file(data, extension=None):
     try:
-        excel_file = pandas.ExcelFile(open(data, 'rU'))
+        excel_file = pandas.ExcelFile(open(data, 'rb'))
         df = pandas.read_excel(excel_file, header=None, index_col=None)
 
     except Exception as e:

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -14,7 +14,6 @@ import ckantoolkit as t
 import shapefile
 import zipfile
 from helpers import validation_load_json_schema
-import ckan.lib.base as base
 from collections import OrderedDict
 from ckanext.validation.model import Validation
 
@@ -184,11 +183,12 @@ def _read_csv_file(data, extension=None):
     try:
         return pandas.read_csv(open(data, 'rb'), header=None, index_col=None)
     except Exception as e:
+        log.warning(e, exc_info=True)
         extension = "(" + extension + ")" if extension else ""
         raise t.ValidationError({
             'Format': [
                 'Could not read your CSV file. Are you sure your specified '
-                'format ' + extension + ' is correct? (' + str(e) + ')'
+                'format {} is correct?'.format(extension)
             ]
         })
 
@@ -199,11 +199,12 @@ def _read_excel_file(data, extension=None):
         df = pandas.read_excel(excel_file, header=None, index_col=None)
 
     except Exception as e:
+        log.warning(e, exc_info=True)
         extension = "(" + extension + ")" if extension else ""
         raise t.ValidationError({
             'Format': [
                 'Could not read your Excel file. Are you sure your specified '
-                'format ' + extension + ' is correct? (' + str(e) + ')'
+                'format {} is correct?'.format(extension)
             ]
         })
 


### PR DESCRIPTION
This PR includes the following changes:
 - Firstly we now catch errors when the file format is wrongly specified in the html form.  the specified file format determines how the data is read for validation.  If the file is an excel file, but the format is specified in the form to be a csv file an exception occurs upon calling pandas.read_csv.  We catch these errors and return a sensible validation error to the user.
- Secondly we read csv and excel files in 'rb' mode rather than 'rU' mode (which is now depricated).  This fixes further errors that occur when trying to read excel files. 
- Thirdly there is some simple refactoring to make the code more friendly to read. 