### PR TITLE
Fix missing foreign key fields error ADX-125

### DIFF
--- a/ckanext/validation/custom_checks.py
+++ b/ckanext/validation/custom_checks.py
@@ -77,16 +77,16 @@ class ForeignKeyCheck(object):
 
             if field.descriptor.get('foreignKey'):
 
-                cache = self.__foreign_fields_cache.get(cell['header'])
-                if not cache:
+                if not self.__foreign_fields_cache.get(cell['header']):
                     self.__foreign_fields_cache = merge_two_dicts(
                         self.__foreign_fields_cache,
                         ForeignKeyCheck._create_foreign_fields_cache([cell])
                     )
 
-                valid_values = self.__foreign_fields_cache[cell['header']]['values']
-                resource_id = self.__foreign_fields_cache[cell['header']]['resource_id']
-                resource_url = self.__foreign_fields_cache[cell['header']]['resource_url']
+                cell_cache = self.__foreign_fields_cache.get(cell['header'])
+                valid_values = cell_cache.get('values', [])
+                resource_id = cell_cache.get('resource_id', "")
+                resource_url = cell_cache.get('resource_url', "")
 
                 # Check if ref resource missing, so we only return one error
                 missing = self._missing_ref.get(field.descriptor.get('name'))

--- a/ckanext/validation/custom_checks.py
+++ b/ckanext/validation/custom_checks.py
@@ -77,6 +77,13 @@ class ForeignKeyCheck(object):
 
             if field.descriptor.get('foreignKey'):
 
+                cache = self.__foreign_fields_cache.get(cell['header'])
+                if not cache:
+                    self.__foreign_fields_cache = merge_two_dicts(
+                        ForeignKeyCheck._create_foreign_fields_cache([cell]),
+                        self.__foreign_fields_cache
+                    )
+
                 valid_values = self.__foreign_fields_cache[cell['header']]['values']
                 resource_id = self.__foreign_fields_cache[cell['header']]['resource_id']
                 resource_url = self.__foreign_fields_cache[cell['header']]['resource_url']
@@ -147,6 +154,7 @@ class ForeignKeyCheck(object):
                     'resource_url': res_url
                 }
 
+        log.debug("Foreign key cache: {}".format(cache))
         return cache
 
     @staticmethod
@@ -185,3 +193,9 @@ def register_translator():
     registry.prepare()
     from pylons import translator
     registry.register(translator, MockTranslator())
+
+
+def merge_two_dicts(x, y):
+    z = x.copy()   # start with x's keys and values
+    z.update(y)    # modifies z with y's keys and values & returns None
+    return z

--- a/ckanext/validation/custom_checks.py
+++ b/ckanext/validation/custom_checks.py
@@ -80,8 +80,8 @@ class ForeignKeyCheck(object):
                 cache = self.__foreign_fields_cache.get(cell['header'])
                 if not cache:
                     self.__foreign_fields_cache = merge_two_dicts(
-                        ForeignKeyCheck._create_foreign_fields_cache([cell]),
-                        self.__foreign_fields_cache
+                        self.__foreign_fields_cache,
+                        ForeignKeyCheck._create_foreign_fields_cache([cell])
                     )
 
                 valid_values = self.__foreign_fields_cache[cell['header']]['values']


### PR DESCRIPTION
If the first row is missing a foreign key field, then the foreign key cache never gets populated with it causing an internal server error.  This fix creates the foreign key cache for any foreign key fields not found in earlier rows.

Jeff's data by default has an "NA" as the parent_area_id for the country.  This was causing an interal server error to occur.

The issue is now fixed.