### PR TITLE
ADX-283 Enable async validation on create.

### DIFF
--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -136,6 +136,7 @@ def resource_validation_run(context, data_dict):
         'validation_status': validation.status,
         'validation_timestamp': validation.created.isoformat()
     }
+    context['_dont_validate'] = True
     t.get_action('resource_patch')(context, data_dict)
 
     if async_job:
@@ -266,7 +267,6 @@ def resource_validation_run_batch(context, data_dict):
 
 
     '''
-
     t.check_access(u'resource_validation_run_batch', context, data_dict)
 
     page = 1
@@ -633,8 +633,8 @@ def resource_update(context, data_dict):
                     context,
                     {'dataset_ids': data_dict.get('package_id')}
                 )
-# Custom code ends
 
+    # Custom code ends
     model.repo.commit()
 
     resource = t.get_action('resource_show')(context, {'id': id})

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -188,10 +188,7 @@ to create the database tables:
             for resource in data_dict.get(u'resources', []):
                 self._handle_validation_for_resource(context, resource)
         else:
-            # This is a resource. Resources don't need to be handled here
-            # as there is always a previous `package_update` call that will
-            # trigger the `before_update` and `after_update` hooks
-            pass
+            _run_async_validation(data_dict['id'])
 
     def _data_dict_is_dataset(self, data_dict):
         return (

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -189,6 +189,11 @@ to create the database tables:
                 self._handle_validation_for_resource(context, resource)
         else:
             _run_async_validation(data_dict['id'])
+            if data_dict.get('validate_package'):
+                t.get_action('resource_validation_run_batch')(
+                    context,
+                    {'dataset_ids': data_dict.get('package_id')}
+                )
 
     def _data_dict_is_dataset(self, data_dict):
         return (
@@ -269,6 +274,12 @@ to create the database tables:
             return
 
         if not is_dataset:
+            if context.get('_dont_validate'):
+                # Ugly, but needed to avoid circular loops caused by the
+                # validation job calling resource_patch (which calls
+                # package_update)
+                del context['_dont_validate']
+                return
             # This is a resource
             resource_id = data_dict[u'id']
             if resource_id in self.resources_to_validate:
@@ -280,17 +291,15 @@ to create the database tables:
                 del self.resources_to_validate[resource_id]
                 _run_async_validation(resource_id)
 
-            if data_dict.get('validate_package'):
-                t.get_action('resource_validation_run_batch')(
-                    context,
-                    {'dataset_ids': data_dict.get('package_id')}
-                )
+                if data_dict.get('validate_package'):
+                    t.get_action('resource_validation_run_batch')(
+                        context,
+                        {'dataset_ids': data_dict.get('package_id')}
+                    )
 
 
     # IPackageController
-
     def before_index(self, index_dict):
-
         res_status = []
         dataset_dict = json.loads(index_dict['validated_data_dict'])
         for resource in dataset_dict.get('resources', []):
@@ -303,7 +312,6 @@ to create the database tables:
         return index_dict
 
     # IValidators
-
     def get_validators(self):
         return {
             'resource_schema_validator': resource_schema_validator,


### PR DESCRIPTION
Default behaviour of async validation was to validate the entire packge on upon every single update operation.  I changed this so that it only validates the entire package if updating a resource with a "validate_package" field.  However, there was a problem with my logic and it wasn't catching the "create" case only the update case.  This little PR fixes that and ensures that resources are properly validated on create.