### PR TITLE
ADX-521 Ammend custom constraints check

### DIFF
--- a/ckanext/validation/custom_checks.py
+++ b/ckanext/validation/custom_checks.py
@@ -11,8 +11,12 @@ log = logging.getLogger(__name__)
 
 
 class CustomConstraint(object):
-
-    # Public
+    """
+    Copied from the core good tables module to alter the behaviour slightly.
+    We want to ignore rows where data does not exist.  The principle here is
+    that the required constraint should be used to catch missing data, not the
+    custom constraint.
+    """
 
     def __init__(self, constraint, **options):
         self.__constraint = constraint
@@ -32,8 +36,11 @@ class CustomConstraint(object):
             # This call should be considered as a safe expression evaluation
             # https://github.com/danthedeckie/simpleeval
             assert simple_eval(self.__constraint, names=names)
+
+        # ADR customisation of the upstream code simply catches NameNotDefined
         except NameNotDefined:
             return []
+
         except Exception:
             row_number = cells[0]['row-number']
             message = 'Custom constraint "{constraint}" fails for row {row_number}'

--- a/ckanext/validation/custom_checks.py
+++ b/ckanext/validation/custom_checks.py
@@ -5,8 +5,48 @@ from collections import namedtuple
 import logging
 from ckan.common import _
 import goodtables.registry
+from simpleeval import simple_eval, NameNotDefined
 
 log = logging.getLogger(__name__)
+
+
+class CustomConstraint(object):
+
+    # Public
+
+    def __init__(self, constraint, **options):
+        self.__constraint = constraint
+
+    def check_row(self, cells):
+        # Prepare names
+        names = {}
+        for cell in cells:
+            if None not in [cell.get('header'), cell.get('value')]:
+                try:
+                    names[cell['header']] = float(cell['value'])
+                except ValueError:
+                    pass
+
+        # Check constraint
+        try:
+            # This call should be considered as a safe expression evaluation
+            # https://github.com/danthedeckie/simpleeval
+            assert simple_eval(self.__constraint, names=names)
+        except NameNotDefined:
+            return []
+        except Exception:
+            row_number = cells[0]['row-number']
+            message = 'Custom constraint "{constraint}" fails for row {row_number}'
+            message_substitutions = {
+                'constraint': self.__constraint,
+            }
+            error = Error(
+                'custom-constraint',
+                row_number=row_number,
+                message=message,
+                message_substitutions=message_substitutions
+            )
+            return [error]
 
 
 def enumerable_constraint(cells):
@@ -311,6 +351,9 @@ def setup_custom_goodtables():
     )
     goodtables.registry.registry.register_check(
         enumerable_constraint, 'enumerable-constraint', None, None, None
+    )
+    goodtables.registry.registry.register_check(
+        CustomConstraint, 'custom-constraint', type='custom', context='body'
     )
 
 

--- a/ckanext/validation/tests/conftest.py
+++ b/ckanext/validation/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+@pytest.fixture(scope='session')
+def log():
+    def fixture(struct):
+        # Pack errors/report to tuples list log:
+        # - format for errors: (row-number, column-number, code)
+        # - format for report: (table-number, row-number, column-number, code)
+        result = []
+        
+        def pack_error(error, table_number='skip'):
+            error = dict(error)
+            error = [
+                error.get('row-number'),
+                error.get('column-number'),
+                error.get('code'),
+            ]
+            if table_number != 'skip':
+                error = [table_number] + error
+            return tuple(error)
+        if isinstance(struct, list):
+            for error in struct:
+                result.append(pack_error(error))
+        if isinstance(struct, dict):
+            for table_number, table in enumerate(struct['tables'], start=1):
+                for error in table['errors']:
+                    result.append(pack_error(error, table_number))
+        return result
+    return fixture

--- a/ckanext/validation/tests/test_custom_checks.py
+++ b/ckanext/validation/tests/test_custom_checks.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from goodtables import validate
+from ckanext.validation.custom_checks import setup_custom_goodtables
+
+setup_custom_goodtables()
+
+
+# Validate
+def test_check_custom_constraint(log):
+    source = [
+        ['row', 'salary', 'bonus'],
+        [2, 1000, 200],
+        [3, 2500, 500],
+        [4, 1300, 500],
+        [5, 5000, 1000],
+        [6, 6000, 2000]
+    ]
+    report = validate(source, checks=[
+        {'custom-constraint': {'constraint': 'salary > bonus * 4'}},
+    ])
+    assert log(report) == [
+        (1, 4, None, 'custom-constraint'),
+        (1, 6, None, 'custom-constraint'),
+    ]
+
+
+def test_check_custom_constraint_for_missing_data(log):
+
+    source = [
+        ['row', 'salary', 'bonus'],
+        [1, None, 500],
+        [2, 5000],
+        [3]
+    ]
+    report = validate(source, checks=[
+        {'custom-constraint': {'constraint': 'salary > bonus * 4'}},
+    ])
+    assert log(report) == []
+
+
+def test_check_custom_constraint_incorrect_constraint(log):
+    source = [
+        ['row', 'name'],
+        [2, 'Alex'],
+    ]
+    report = validate(source, checks=[
+        {'custom-constraint': {'constraint': 'vars()'}},
+        {'custom-constraint': {'constraint': 'import(os)'}}
+    ])
+    assert log(report) == [
+        (1, 2, None, 'custom-constraint'),
+        (1, 2, None, 'custom-constraint'),
+    ]

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.


### PR DESCRIPTION
This PR copies the existing custom-constraint check from goodtables-py and ammends it's behaviour slightly. 

A custom constraint is a simple expression to be evaluated to a boolean, using the column headings of the data table.  It allows us to check, e.g. Column A + Column B <= Column C for all rows. 

But what if Column B has missing data, should the check fail, or be ignored?

Jeff has said that in all our uses of these custom-constraints presently, the check should just be ignored.  This PR implements this by catching the "NameNotFound" error that is thrown by the simple_eval function. 