### PR TITLE
ADX-654 Validation Reports Bug

### DIFF
--- a/ckanext/validation/assets/webassets.yml
+++ b/ckanext/validation/assets/webassets.yml
@@ -7,6 +7,9 @@ resource_schema_form_js:
     output: validation/%(version)s_resource_schema_form.js
     contents:
         - js/module-resource-schema.js
+    extra:
+      preload:
+        - base/main
 
 report_form_js:
     output: validation/%(version)s_report_form.js
@@ -14,6 +17,9 @@ report_form_js:
         - vendor/goodtables-ui/goodtables-ui.js
         - js/module-validation-report.js
         - js/module-modal-dialog.js
+    extra:
+      preload:
+        - base/main
 
 report_form_css:
     output: validation/%(version)s_report_form.css
@@ -27,6 +33,10 @@ report_js:
     contents:
         - vendor/goodtables-ui/goodtables-ui.js
         - js/module-validation-report.js
+    extra:
+      preload:
+        - base/main
+
 
 report_css:
     output: validation/%(version)s_report.css


### PR DESCRIPTION
Validation reports aren't showing after web assets upgrade. 

The problem is that `this.ckan` isn't defined at the point of running the js code. 

This fix preloads `base/main` js module that includes this.ckan prior to loading the validation js.