### PR TITLE
ADX-716 Use giftless for getting resource data in validation bg jobs.

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -299,7 +299,7 @@ def _read_json_file(json_url):
     # Load as plain JSON
     try:
         r = requests.get(json_url)
-        geojson = json.load(StringIO(r.content))
+        geojson = r.json()
     except Exception as e:
         log.exception(e)
         raise t.ValidationError({


### PR DESCRIPTION
Not an ideal solution but something to quick fix current bug of total lack of validation.
I couldn't get the old mechanism to work in parallel (support for classic uploader is broken now).
All of the tests are skipped as well since our 2.9 upgrade. They're not passing in GitHub action either now (unskipped tests passed for me though locally).

