### PR TITLE
ADX-740 persist validation keys.

### DIFF
--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -222,6 +222,14 @@ to create the database tables:
 
     def before_update(self, context, current_resource, updated_resource):
 
+        # Anything not part of the UI form submission is lost during resource_update
+        # validation_status and validation_timestamp are not submitted through the form
+        # We have to explicitly persist these keys through a resource_update
+        for key_to_persist in ['validation_status', 'validation_timestamp']:
+            if (key_to_persist in current_resource and
+                    key_to_persist not in updated_resource):
+                updated_resource[key_to_persist] = current_resource[key_to_persist]
+
         updated_resource = self._process_schema_fields(updated_resource)
 
         if not get_update_mode_from_config() == u'async':
@@ -253,7 +261,6 @@ to create the database tables:
 
     def after_update(self, context, data_dict):
         is_dataset = self._data_dict_is_dataset(data_dict)
-
         # Need to allow create as well because resource_create calls
         # package_update
         if (not get_update_mode_from_config() == u'async'

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -221,7 +221,6 @@ to create the database tables:
             _run_async_validation(resource[u'id'])
 
     def before_update(self, context, current_resource, updated_resource):
-
         # Anything not part of the UI form submission is lost during resource_update
         # validation_status and validation_timestamp are not submitted through the form
         # We have to explicitly persist these keys through a resource_update

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -221,9 +221,7 @@ to create the database tables:
             _run_async_validation(resource[u'id'])
 
     def before_update(self, context, current_resource, updated_resource):
-        # Anything not part of the UI form submission is lost during resource_update
-        # validation_status and validation_timestamp are not submitted through the form
-        # We have to explicitly persist these keys through a resource_update
+
         for key_to_persist in ['validation_status', 'validation_timestamp']:
             if (key_to_persist in current_resource and
                     key_to_persist not in updated_resource):

--- a/ckanext/validation/tests/test_plugin.py
+++ b/ckanext/validation/tests/test_plugin.py
@@ -34,6 +34,27 @@ class TestResourceControllerHooksUpdate(object):
 
     @change_config('ckanext.validation.run_on_create_async', False)
     @mock.patch('ckanext.validation.logic.enqueue_job')
+    def test_validation_keys_persisted(self, mock_enqueue):
+
+        original_resource = {
+            "format": "CSV",
+            "validation_timestamp": "2021-09-02T10:02:42.936205",
+            "validation_status": "failed"
+        }
+
+        dataset = factories.Dataset(resources=[original_resource])
+
+        dataset['resources'][0]['description'] = 'Some resource'
+        del dataset['resources'][0]['validation_timestamp']
+        del dataset['resources'][0]['validation_status']
+
+        updated_resource = call_action('resource_update', {}, **dataset['resources'][0])
+
+        assert updated_resource['validation_timestamp'] == original_resource['validation_timestamp']
+        assert updated_resource['validation_status'] == original_resource['validation_status']
+
+    @change_config('ckanext.validation.run_on_create_async', False)
+    @mock.patch('ckanext.validation.logic.enqueue_job')
     def test_validation_does_not_run_on_other_formats(self, mock_enqueue):
 
         resource = {'format': 'PDF'}

--- a/ckanext/validation/tests/test_plugin.py
+++ b/ckanext/validation/tests/test_plugin.py
@@ -43,14 +43,13 @@ class TestResourceControllerHooksUpdate(object):
             "validation_timestamp": "2021-09-02T10:02:42.936205",
             "validation_status": "failed"
         }
-
         dataset = factories.Dataset(resources=[original_resource])
 
-        dataset['resources'][0]['description'] = 'Some resource'
-        del dataset['resources'][0]['validation_timestamp']
-        del dataset['resources'][0]['validation_status']
-
-        updated_resource = call_action('resource_update', {}, **dataset['resources'][0])
+        updated_resource = dataset['resources'][0]
+        updated_resource['description'] = 'Some resource'
+        del updated_resource['validation_timestamp']
+        del updated_resource['validation_status']
+        updated_resource = call_action('resource_update', {}, **updated_resource)
 
         assert updated_resource['validation_timestamp'] == original_resource['validation_timestamp']
         assert updated_resource['validation_status'] == original_resource['validation_status']

--- a/ckanext/validation/tests/test_plugin.py
+++ b/ckanext/validation/tests/test_plugin.py
@@ -11,6 +11,8 @@ from ckanext.validation.model import create_tables, tables_exist
 from ckanext.validation.jobs import run_validation_job
 
 
+@pytest.mark.ckan_config('ckan.plugins', 'validation')
+@pytest.mark.usefixtures('with_plugins')
 class TestResourceControllerHooksUpdate(object):
 
     def setup(self):


### PR DESCRIPTION
**Problem:**     

The  `validation_status` and `validation_timestamps` fields was dropped by the resource_update action.  In cases where no new resource validation is triggered (e.g. just edit the description field), these fields were simply being lost and so the validation badge and report was being dropped from the front end. 

**Solution:**

This was a funny one - as I didn't think it was originally broken, but I can't find any reason why it hasn't always been broken!

Resource update completely replaces the resource with the given data dict.  Resource patch updates only specified fields from the data dict.  Resource update is called by the UI.  So any fields not submitted from the UI through the form submission are dropped during resource_update. 

I can see elsewhere where fields are having being explicitly persisted through a resource_update action e.g. `datastore_active` field. is explicitly persisted in the core resource_update logic, to avoid it being dropped in exactly the same way I am persisting the validation fields here. 

I can only assume that the same should be done for validation fields, it definitely appears to fix the issue. 