### PR TITLE
ADX-742 Catch all possible exceptions in a validation job.

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -46,6 +46,16 @@ def run_validation_job(resource):
         validation.status = 'error'
         validation.error = e.error_summary
         validation.report = {'valid': False}
+    except Exception as e:
+        error = t.ValidationError({
+            _('System Error'): [
+                _('A system error occured, please contact system administrator: ') + str(e)
+            ]
+        })
+        validation.status = 'error'
+        validation.error = error.error_summary
+        validation.report = {'valid': False}
+        log.exception(e)
     finally:
         _finish_validation_job(validation, resource)
 


### PR DESCRIPTION
Uses an `except Exception` to catch all possible errors and send the error back to the frontend.  The error stack trace is also logged. This should stop the problem of some jobs running indefinately.