### PR TITLE
ADX-714 Fix jenkins build by fixing jsonschema version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ goodtables==2.2.1
 pandas==0.24.2
 pyshp==2.1.0
 pyrsistent==0.16.0
+jsonschema==3.2.0


### PR DESCRIPTION
jsonschema version 4.0.0 is incompatible with python 2.7

Fix the dependancy at 3.2.0 - the last version of the dependancy used in a working Jenkins build.