### PR TITLE
ADX-758 Only batch-validate resources in package with schema field.

### DIFF
--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -310,6 +310,8 @@ def resource_validation_run_batch(context, data_dict):
                     if (not resource.get(u'format', u'').lower()
                             in settings.SUPPORTED_FORMATS):
                         continue
+                    elif not resource.get(u'schema'):
+                        continue
 
                     try:
                         t.get_action(u'resource_validation_run')(


### PR DESCRIPTION
This fixes the sentry bug: https://sentry.io/organizations/fjelltopp/issues/2754408006/?project=1411020&referrer=slack

When uploading geodata we were triggering batch validation across the dataset, and it was attempting to validate all files, not just just those with a schema set. 