### PR TITLE
ADX-761 data loading bug

### DIFF
--- a/ckanext/validation/helpers.py
+++ b/ckanext/validation/helpers.py
@@ -212,5 +212,4 @@ def _files_from_directory(path, extension='.json'):
 
 def validation_get_goodtables_spec():
     spec_override = get_spec_override()
-    log.warning("Spec Override: {}".format(spec_override))
     return json.dumps(spec_override, sort_keys=True)

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -83,16 +83,16 @@ def _validate(resource, validation):
     if resource.get(u'url_type') == u'upload':
         if core.plugin_loaded('blob_storage'):
             app_context = _get_auto_flask_context()
-            if app_context:
-                with app_context:
+            try:
+                if app_context:
+                    app_context.push()
                     g.user = t.get_action('get_site_user')({'ignore_auth': True})['name']
-                    source = toolkit.get_action('get_resource_download_spec')(
-                        {'ignore_auth': True}, {'id': resource['id']}
-                    ).get('href')
-            else:
                 source = toolkit.get_action('get_resource_download_spec')(
                     {'ignore_auth': True}, {'id': resource['id']}
                 ).get('href')
+            finally:
+                if app_context:
+                    app_context.pop()
         else:
             upload = uploader.get_resource_uploader(resource)
             if isinstance(upload, uploader.ResourceUpload):

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -83,16 +83,16 @@ def _validate(resource, validation):
     if resource.get(u'url_type') == u'upload':
         if core.plugin_loaded('blob_storage'):
             app_context = _get_auto_flask_context()
-            try:
-                if app_context:
-                    app_context.push()
+            if app_context:
+                with app_context:
                     g.user = t.get_action('get_site_user')({'ignore_auth': True})['name']
+                    source = toolkit.get_action('get_resource_download_spec')(
+                        {'ignore_auth': True}, {'id': resource['id']}
+                    ).get('href')
+            else:
                 source = toolkit.get_action('get_resource_download_spec')(
                     {'ignore_auth': True}, {'id': resource['id']}
                 ).get('href')
-            finally:
-                if app_context:
-                    app_context.pop()
         else:
             upload = uploader.get_resource_uploader(resource)
             if isinstance(upload, uploader.ResourceUpload):

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from six import string_types
 from sqlalchemy.orm.exc import NoResultFound
 from goodtables import validate
-from ckan.common import _
+from ckan.common import _, g
 from ckan.model import Session
 import ckan.lib.uploader as uploader
 import ckantoolkit as t
@@ -20,7 +20,7 @@ from ckan.plugins import toolkit, core
 from ckanext.validation.helpers import validation_load_json_schema
 from ckanext.validation.model import Validation
 from ckanext.validation.custom_checks import setup_custom_goodtables
-
+from ckan.lib.helpers import _get_auto_flask_context
 log = logging.getLogger(__name__)
 
 
@@ -82,10 +82,17 @@ def _validate(resource, validation):
     source = None
     if resource.get(u'url_type') == u'upload':
         if core.plugin_loaded('blob_storage'):
-            source = toolkit.get_action('get_resource_download_spec')(
-                {'ignore_auth': True},
-                {'id': resource['id']}
-            ).get('href')
+            app_context = _get_auto_flask_context()
+            if app_context:
+                with app_context:
+                    g.user = t.get_action('get_site_user')({'ignore_auth': True})['name']
+                    source = toolkit.get_action('get_resource_download_spec')(
+                        {'ignore_auth': True}, {'id': resource['id']}
+                    ).get('href')
+            else:
+                source = toolkit.get_action('get_resource_download_spec')(
+                    {'ignore_auth': True}, {'id': resource['id']}
+                ).get('href')
         else:
             upload = uploader.get_resource_uploader(resource)
             if isinstance(upload, uploader.ResourceUpload):


### PR DESCRIPTION
This is a solution to ADX-761.  But I should acknowledge that I feel like I am a bit "out-in-the-wild-west" here. 

All ears to hear better possible solutions. 

Some comments:

- I'm using `_get_auto_flask_context` specifically (I know it is supposed to be a private function) to show that I'm not quite as far out in the wild west as it might seem.  This is a problem already faced when running cli commands or testing, and I am simply adopting the same strategy. 
- I think the real root of the problem is that ckanext-blob-storage requires a flask app context. It shouldn't really. 
- There are two obvious ways to express this solution that I can currently think of, neither are super clean - I have no particularly strong opinions about which option is most readable:
  - Using a with statement to ensure that the app context is always popped at the end of the code block as in  https://github.com/fjelltopp/ckanext-validation/commit/cf916f54542a08b184608592e85a2e6c7ceb7704 
  - Or using `try` and `finally` without `except` to always pop the app context but ensure that any errors thrown are still raised as in https://github.com/fjelltopp/ckanext-validation/pull/85/commits/7feb3fa63a108dc857eec11e30b7cf74923a99f2. 

[EDIT: But on reflection I think I personally prefer the `with` statement.]