### PR TITLE
ADX-772 Fix unicode bug

### DIFF
--- a/ckanext/validation/custom_checks.py
+++ b/ckanext/validation/custom_checks.py
@@ -44,7 +44,7 @@ class CustomConstraint(object):
 
         except Exception:
             row_number = cells[0]['row-number']
-            message = 'Custom constraint "{constraint}" fails for row {row_number}'
+            message = u'Custom constraint "{constraint}" fails for row {row_number}'
             message_substitutions = {
                 'constraint': self.__constraint,
             }
@@ -74,8 +74,8 @@ def enumerable_constraint(cells):
         # Add error
         if not valid:
             message_substitutions = {
-                'value': '"{}"'.format(value),
-                'constraint': '"{}"'.format('", "'.join(field.constraints['enum']))
+                'value': u'"{}"'.format(value),
+                'constraint': u'"{}"'.format('", "'.join(field.constraints['enum']))
             }
             error = Error(
                 'enumerable-constraint',


### PR DESCRIPTION
Just makes sure we are working with unicode in a few more places.

This fixes a client reported bugreported by Ian this morning. 

I've spent a little while trying to write a regression test and failed.  If someone else wants to try and pick this up they are welcome to try.

For some reason the mocker fixture wasn't available and I also couldn't import mock from unittest. 