### PR TITLE
ADX-960 foreign key validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: "3.8"
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
@@ -35,7 +35,7 @@ jobs:
           POSTGRES_DB: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
-          image: redis:3
+        image: redis:3
     env:
       CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
       CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test
@@ -44,23 +44,23 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install requirements
-      run: |
-        pip install -r dev-requirements.txt
-        pip install -r requirements.txt
-        pip install --no-warn-conflicts jinja2==2.10.1
-        pip install --no-warn-conflicts markupsafe==2.0.1
-        pip install -e .
-        # Replace default path to CKAN core config file with the one on the container
-        sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
-    - name: Setup extension
-      run: |
-        ckan -c test.ini db init
-    - name: Run tests
-      run: pytest --ckan-ini=test.ini --cov=ckanext.validation --cov-report=xml --cov-append --disable-warnings ckanext/validation/tests -vv
+      - uses: actions/checkout@v2
+      - name: Install requirements
+        run: |
+          pip install -r dev-requirements.txt
+          pip install -r requirements.txt
+          pip install --no-warn-conflicts jinja2==2.10.1
+          pip install --no-warn-conflicts markupsafe==2.0.1
+          pip install -e .
+          # Replace default path to CKAN core config file with the one on the container
+          sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+      - name: Setup extension
+        run: |
+          ckan -c test.ini db init
+      - name: Run tests
+        run: pytest --ckan-ini=test.ini --cov=ckanext.validation --cov-report=xml --cov-append --disable-warnings ckanext/validation/tests -vv
 
-    - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -262,6 +262,30 @@ With the extension enabled and configured, schemas can be attached to the
 `schema` field on resources via the UI form or the API. If present in a
 resource, they will be used when performing validation on the resource file.
 
+#### Foreign Keys
+
+As per the Frictionless Framework, ckanext-validation can also be used to
+validate foreign keys. This is done by adding a `foreignKeys` property to the
+schema, with the following format:
+
+```json
+{
+    "foreignKeys": [
+        {
+            "fields": "location",
+            "reference": {
+                "resource": "locations",
+                "fields": "code"
+            }
+        }
+    ]
+}
+```
+
+This will validate that the values in the `location` column are present in the
+`code` column of the `locations` resource. The `resource` property can be
+either the full url of a resource, a valid Frictionless Schema in JSON or the
+`resource_type` that matches another resource within the CKAN dataset.
 
 ### Validation Options
 

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -64,7 +64,7 @@ def run_validation_job(resource):
             # implementation)
             pass_auth_header = t.asbool(
                 t.config.get('ckanext.validation.pass_auth_header', True))
-            if dataset['private'] and pass_auth_header:
+            if pass_auth_header:
                 s = requests.Session()
                 s.headers.update({
                     'Authorization': t.config.get(

--- a/ckanext/validation/tests/test_interfaces.py
+++ b/ckanext/validation/tests/test_interfaces.py
@@ -55,7 +55,7 @@ class TestInterfaceSync():
     @pytest.mark.ckan_config('ckanext.validation.run_on_create_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_update_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_create_sync', True)
-    @mock.patch('ckanext.validation.jobs.validate',
+    @mock.patch('frictionless.Package.validate',
                 return_value=VALID_REPORT)
     def test_can_validate_called_on_create_sync(self, mock_validation):
 
@@ -73,7 +73,7 @@ class TestInterfaceSync():
     @pytest.mark.ckan_config('ckanext.validation.run_on_create_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_update_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_create_sync', True)
-    @mock.patch('ckanext.validation.jobs.validate')
+    @mock.patch('frictionless.Package.validate')
     def test_can_validate_called_on_create_sync_no_validation(self, mock_validation):
 
         dataset = factories.Dataset()
@@ -91,7 +91,7 @@ class TestInterfaceSync():
     @pytest.mark.ckan_config('ckanext.validation.run_on_create_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_update_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_update_sync', True)
-    @mock.patch('ckanext.validation.jobs.validate',
+    @mock.patch('frictionless.Package.validate',
                 return_value=VALID_REPORT)
     def test_can_validate_called_on_update_sync(self, mock_validation):
 
@@ -113,7 +113,7 @@ class TestInterfaceSync():
     @pytest.mark.ckan_config('ckanext.validation.run_on_create_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_update_async', False)
     @pytest.mark.ckan_config('ckanext.validation.run_on_update_sync', True)
-    @mock.patch('ckanext.validation.jobs.validate')
+    @mock.patch('frictionless.Package.validate')
     def test_can_validate_called_on_update_sync_no_validation(self, mock_validation):
 
         dataset = factories.Dataset()

--- a/ckanext/validation/tests/test_logic.py
+++ b/ckanext/validation/tests/test_logic.py
@@ -347,8 +347,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset['id'])
 
         context = {"user": user["name"], "model": model}
 
@@ -357,7 +358,7 @@ class TestAuth(object):
             call_auth,
             "resource_validation_run",
             context=context,
-            resource_id=dataset["resources"][0]["id"],
+            resource_id=resource["id"],
         )
 
     def test_run_auth_user(self):
@@ -367,8 +368,9 @@ class TestAuth(object):
             users=[{"name": user["name"], "capacity": "editor"}]
         )
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset['id'])
 
         context = {"user": user["name"], "model": model}
 
@@ -376,7 +378,7 @@ class TestAuth(object):
             call_auth(
                 "resource_validation_run",
                 context=context,
-                resource_id=dataset["resources"][0]["id"],
+                resource_id=resource["id"],
             )
             is True
         )
@@ -416,8 +418,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset['id'])
 
         context = {"user": user["name"], "model": model}
 
@@ -426,7 +429,7 @@ class TestAuth(object):
             call_auth,
             "resource_validation_delete",
             context=context,
-            resource_id=dataset["resources"][0]["id"],
+            resource_id=resource["id"],
         )
 
     def test_delete_auth_user(self):
@@ -436,8 +439,9 @@ class TestAuth(object):
             users=[{"name": user["name"], "capacity": "editor"}]
         )
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()]
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset['id'])
 
         context = {"user": user["name"], "model": model}
 
@@ -445,7 +449,7 @@ class TestAuth(object):
             call_auth(
                 "resource_validation_delete",
                 context=context,
-                resource_id=dataset["resources"][0]["id"],
+                resource_id=resource["id"],
             )
             is True
         )
@@ -468,8 +472,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()], private=False
+            owner_org=org["id"], private=False
         )
+        resource = factories.Resource(package_id=dataset['id'])
 
         context = {"user": user["name"], "model": model}
 
@@ -477,7 +482,7 @@ class TestAuth(object):
             call_auth(
                 "resource_validation_show",
                 context=context,
-                resource_id=dataset["resources"][0]["id"],
+                resource_id=resource["id"],
             )
             is True
         )
@@ -487,8 +492,9 @@ class TestAuth(object):
         user = factories.User()
         org = factories.Organization()
         dataset = factories.Dataset(
-            owner_org=org["id"], resources=[factories.Resource()], private=True
+            owner_org=org["id"]
         )
+        resource = factories.Resource(package_id=dataset['id'])
 
         context = {"user": user["name"], "model": model}
 
@@ -497,7 +503,7 @@ class TestAuth(object):
             call_auth,
             "resource_validation_run",
             context=context,
-            resource_id=dataset["resources"][0]["id"],
+            resource_id=resource["id"],
         )
 
 

--- a/ckanext/validation/tests/test_logic.py
+++ b/ckanext/validation/tests/test_logic.py
@@ -575,7 +575,7 @@ class TestResourceValidationOnCreate(object):
         assert resource["validation_status"] == "success"
         assert "validation_timestamp" in resource
 
-    @mock.patch("ckanext.validation.jobs.validate", return_value=VALID_REPORT)
+    @mock.patch("frictionless.Package.validate", return_value=VALID_REPORT)
     def test_validation_passes_with_url(self, mock_validate):
 
         url = "https://example.com/valid.csv"
@@ -672,7 +672,7 @@ class TestResourceValidationOnUpdate(object):
         assert resource["validation_status"] == "success"
         assert "validation_timestamp" in resource
 
-    @mock.patch("ckanext.validation.jobs.validate", return_value=VALID_REPORT)
+    @mock.patch("frictionless.Package.validate", return_value=VALID_REPORT)
     def test_validation_passes_with_url(self, mock_validate):
 
         dataset = factories.Dataset(resources=[{"url": "https://example.com/data.csv"}])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ckantoolkit>=0.0.3
-frictionless==5.0.0b9
+frictionless[ckan]==5.0.0b9
 markupsafe==2.0.1
 tableschema
 -e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ host = 0.0.0.0
 port = 5000
 
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.


### PR DESCRIPTION
## Description

**Please note that this is a local Fjelltopp PR for initial review before creating an upstream PR. This ensure that the solution works for us before we merge upstream.**

See [ADX-960](https://fjelltopp.atlassian.net/browse/ADX-960?atlOrigin=eyJpIjoiZjM5NDUzOTllOWU0NGY1MDk5M2FmZjk3MjZkNzJmNGUiLCJwIjoiaiJ9) for our ticket.

See frictionlessdata/ckanext-validation#84 for the community discussion on this.

Basically, this is a rewrite of upstream to use the frictionless [Package](https://framework.frictionlessdata.io/docs/framework/package.html) object, instead of the [Resource](https://framework.frictionlessdata.io/docs/framework/resource.html) object.

This allows us to then pass in multiple resources and do the following:
 - if "foreignKeys" is in the schema we collect together `schema["foreignKeys"][i]["reference"]["resource"]
 - we go through and check if the referenced resource is a url (path), json object (data) or (the fall back) is a resource name that can be found within this ckan dataset; if none are true then we return a `ValidationError`
 - these can be added to our `Package` object for frictionless framework to utilise during validation

### !BREAKING CHANGE!

Actually, currently unaids_data_specifications uses _schema names_ for `schema["foreignKeys"][i]["reference"]["resource"]` but this probably doesn't generalise as it very much assumes _our_ fork of ckanext-scheming. Instead, for this PR, I am changing this to use what we call `resource_type`... I think this has the pro that we won't have to update the our table_schemas if we updates our package_schemas - foreign keys will now always follow the package_schema whereas (theroretically) you could have had a table_schema with a foreign key using a different schema version than a package_schema, which seems silly.

### TODO

- [ ] exploratory tests with our unaids_data_specifications
- [ ] exploratory tests with vanilla ckan and upstream ckanext-scheming
- [ ] run upstream test suite on vanilla ckan with upstream ckanext-scheming
- [ ] automated tests (recommendations welcome)
- [ ] documentation update
- [ ] [ADX-989](https://fjelltopp.atlassian.net/browse/ADX-989?atlOrigin=eyJpIjoiMWQwNzY2NjBjZTdhNGEzMjgxNDM2MzRkNzcyMDY0ZDAiLCJwIjoiaiJ9)

see also fjelltopp/adx_deploy#132
see also fjelltopp/unaids_data_specifications#58

## Testing

TODO

## Documentation

TODO

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.


[ADX-960]: https://fjelltopp.atlassian.net/browse/ADX-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADX-989]: https://fjelltopp.atlassian.net/browse/ADX-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ