### PR TITLE
ADX-1016 Upgrade to latest frictionless v5.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ckantoolkit>=0.0.3
-frictionless[ckan]==5.0.0b9
+frictionless[ckan]==5.13.1
 markupsafe==2.0.1
 tableschema
 -e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming


### PR DESCRIPTION
## Description

As it says on the tin really.

Tested this locally on a vanilla ckan and all tests pass fine.

Seems like a simple update! Wahoo :tada:

## Dependency Changes

Upgrades frictionless only. This will have knock-on effects for jinja2 but as we are force installed b 2.10.1 right now anyway, this is fine.

## Testing

ckanext-validation test suite passes on vanilla ckan.

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [x] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
