### PR TITLE
ADX-949 check for schema_sync in options

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -178,6 +178,11 @@ def _validate_table(source, _format='csv', schema=None, reference_resources=[], 
     limit_errors = options.pop('limit_errors', None)
     limit_rows = options.pop('limit_rows', None)
 
+    # handle schema sync
+    if 'schema_sync' in options:
+        schema_sync = options.pop('schema_sync', False)
+        options['detector'] = Detector(schema_sync=schema_sync)
+
     with system.use_context(**frictionless_context):
         # load source as frictionless Resource
         if resource_schema:

--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -178,7 +178,7 @@ def _validate_table(source, _format='csv', schema=None, reference_resources=[], 
     limit_errors = options.pop('limit_errors', None)
     limit_rows = options.pop('limit_rows', None)
 
-    # handle schema sync
+    # handle schema_sync frictionless option that ignores header (column) ordering
     if 'schema_sync' in options:
         schema_sync = options.pop('schema_sync', False)
         options['detector'] = Detector(schema_sync=schema_sync)


### PR DESCRIPTION
## Description

`schema_sync` is the frictionless option that ignores header (column) ordering - this PR makes this visible for us to pass in through `ckanext.validation.default_validation_options` in the adx config.

We might want to think about creating an issue / PR pair upstream for this one?

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
