### PR TITLE
ADX-949 handle blob storage plugin when getting files

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -13,6 +13,7 @@ from ckan.model import Session
 import ckan.lib.uploader as uploader
 
 import ckantoolkit as t
+from ckan.plugins import core
 
 from ckanext.validation.model import Validation
 from ckanext.validation.utils import get_update_mode_from_config
@@ -57,7 +58,7 @@ def run_validation_job(resource):
     source = None
     if resource.get('url_type') == 'upload':
         upload = uploader.get_resource_uploader(resource)
-        if isinstance(upload, uploader.ResourceUpload):
+        if isinstance(upload, uploader.ResourceUpload) and not core.plugin_loaded('blob_storage'):
             source = upload.get_path(resource['id'])
         else:
             # Upload is not the default implementation (ie it's a cloud storage


### PR DESCRIPTION
## Description

This seems to be the minimum change required to get the plugin to work with ckanext-blobstorage.

This will be a patch that we will need to maintain in the future.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
