### PR TITLE
ADX-1021 Patch for requirements.txt

### DIFF
--- a/ckanext-unaids-requirements.txt
+++ b/ckanext-unaids-requirements.txt
@@ -2,4 +2,3 @@ ckantoolkit>=0.0.3
 frictionless[ckan]==5.13.1
 markupsafe==2.0.1
 tableschema
--e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ ckantoolkit>=0.0.3
 frictionless[ckan]==5.13.1
 markupsafe==2.0.1
 tableschema
--e git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming


### PR DESCRIPTION
## ADX-1021 Patch for requirements.txt

## Description

In the past, fjelltopp's fork of ckanext-validation provided [requirements.py3.txt file](https://github.com/fjelltopp/ckanext-validation/commit/34bbbb1f71821f3821642b8599d53ae270d0a30f) that was later used in GitHub's [tests of ckanext-unaids](https://github.com/fjelltopp/ckanext-unaids/blob/8d6bcd022bd2a279acc52172701af0f35fb0a166/.github/workflows/test.yml#L34C81-L34C81). Since now we use latest code from frictionless, this file is absent, we use regular requirements.txt - but this file needs to be patched, since it contains dependency on CKAN's implementation of ckanext-scheming, while ckanext-unaids usess Fjelltopp's fork.

relates fjelltopp/repository_name#issue_number

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
