### PR TITLE
ADX-949 patch how ckanext-validation handles foreign keys and their schemas

### DIFF
--- a/ckanext/validation/jobs.py
+++ b/ckanext/validation/jobs.py
@@ -15,6 +15,8 @@ import ckan.lib.uploader as uploader
 import ckantoolkit as t
 from ckan.plugins import core
 
+from ckanext.scheming.helpers import scheming_get_dataset_schema
+
 from ckanext.validation.model import Validation
 from ckanext.validation.utils import get_update_mode_from_config
 
@@ -247,8 +249,7 @@ def _prepare_foreign_keys(dataset, schema):
             log.debug('Foreign Key resource is (presumably) a resource in this dataset.')
 
             # get the available resources in this dataset
-            dataset_resources = [{r.get('resource_type'): {'url':r.get('url'), 'format': r.get('format')}} for r in dataset['resources']]
-            dataset_resources = {k:v for list_item in dataset_resources for (k,v) in list_item.items()}
+            dataset_resources = {_validation_get_schema(dataset['type'], r.get('resource_type')): {'url':r.get('url'), 'format': r.get('format')} for r in dataset['resources']}
 
             # check foreign key resource is in the dataset and get the url
             # if it turns out it isn't we will raise an exception
@@ -267,6 +268,14 @@ def _prepare_foreign_keys(dataset, schema):
 
     log.debug('Foreign key resources required: ' + str(referenced_resources))
     return referenced_resources
+
+def _validation_get_schema(dataset_type, resource_type):
+    schema = scheming_get_dataset_schema(dataset_type)
+    for resource in schema.get('resources', []):
+        if resource.get("resource_type", "") == resource_type:
+            for field in resource.get('resource_fields', []):
+                if field['field_name'] == "schema":
+                    return field['field_value']
 
 def _get_site_user_api_key():
 


### PR DESCRIPTION
## Description

As detailed in #103 and related PRs I fundamentally changed how foreign keys are denoted - at the time this felt like the only solution that was a) general, and so could be pushed upstream, and b) worked with only a minor change to our current approach. However, yesterday it suddenly dawned on me that this actually completely broke our current approach.

The attached is a patch that reimplements some logic from our old fork to solve this problem.

relates fjelltopp/unaids_data_specifications#

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
