### PR TITLE
ADX-1046 No longer need _dont_validate context param

### DIFF
--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -135,8 +135,7 @@ def resource_validation_run(context, data_dict):
 
     patch_context = {
         'ignore_auth': True,
-        'user': t.get_action('get_site_user')({'ignore_auth': True})['name'],
-        '_dont_validate': True,
+        'user': t.get_action('get_site_user')({'ignore_auth': True})['name']
     }
     t.get_action('resource_patch')(patch_context, data_dict)
 


### PR DESCRIPTION
## Description

The _dont_validate context param appears to have only been used to avoid triggering package validation when patching the package with the finalised validation_status.

Since we have properly implemented a change to avoid metadata changes triggering package validation, this is no longer needed. Context params like this are a bit dodgy and it is best to clean it up if we can. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
