### PR TITLE
Fix: TypeError when validation.report is already a dict

### DIFF
--- a/ckanext/validation/helpers.py
+++ b/ckanext/validation/helpers.py
@@ -73,7 +73,9 @@ click the button below to replace the file.''')
     return report, errors
 
 def validation_dict(validation_json):
-    return json.loads(validation_json)
+    if isinstance(validation_json, (str, bytes, bytearray)):
+        return json.loads(validation_json)
+    return validation_json
 
 def dump_json_value(value, indent=None):
     """


### PR DESCRIPTION
## Summary

500 error (`TypeError: the JSON object must be str, bytes or bytearray, not dict`) on `/dataset/{id}/resource/{id}/validation` for resources whose validation report comes back from the DB as a dict rather than a JSON string. Confirmed live in prod/staging logs (~76 occurrences in 24h across both environments).

## Root cause

`validation.report` is `Column(JSON)` (`ckanext/validation/model.py`), which SQLAlchemy auto-deserializes to a Python `dict` on read. `validation_dict()` (used by `validation_read.html`) unconditionally called `json.loads()` on it, assuming it was always still a raw string. This only breaks for rows where `report` comes back as a genuine dict -- other rows apparently still have it stored as a double-encoded JSON string from some other write path, which is why this wasn't hitting every single validation view.

## Fix

Only call `json.loads()` when the value is actually string-like; otherwise return it as-is.