### PR TITLE
Fix flaky io.open mock causing 'read of closed file' in CI

### DIFF
--- a/ckanext/validation/tests/test_jobs.py
+++ b/ckanext/validation/tests/test_jobs.py
@@ -233,9 +233,7 @@ class TestValidationJob(object):
 
         resource = factories.Resource(format="csv", upload=mock_upload)
 
-        invalid_stream = io.BufferedReader(io.BytesIO(invalid_csv.encode('utf8')))
-
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=lambda *a, **k: io.BufferedReader(io.BytesIO(invalid_csv.encode('utf8')))):
             run_validation_job(resource)
 
         validation = (
@@ -279,9 +277,7 @@ a;b;c
             format="csv", upload=mock_upload, validation_options=validation_options
         )
 
-        invalid_stream = io.BufferedReader(io.BytesIO(invalid_csv.encode('utf8')))
-
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=lambda *a, **k: io.BufferedReader(io.BytesIO(invalid_csv.encode('utf8')))):
 
             run_validation_job(resource)
 

--- a/ckanext/validation/tests/test_logic.py
+++ b/ckanext/validation/tests/test_logic.py
@@ -566,9 +566,7 @@ class TestResourceValidationOnCreate(object):
 
         dataset = factories.Dataset()
 
-        valid_stream = io.BufferedReader(io.BytesIO(VALID_CSV.encode('utf8')))
-
-        with mock.patch("io.open", return_value=valid_stream):
+        with mock.patch("io.open", side_effect=lambda *a, **k: io.BufferedReader(io.BytesIO(VALID_CSV.encode('utf8')))):
 
             resource = call_action(
                 "resource_create",
@@ -611,9 +609,7 @@ class TestResourceValidationOnUpdate(object):
 
         mock_upload = MockFieldStorage(invalid_file, "invalid.csv")
 
-        invalid_stream = io.BufferedReader(io.BytesIO(INVALID_CSV.encode('utf8')))
-
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=lambda *a, **k: io.BufferedReader(io.BytesIO(INVALID_CSV.encode('utf8')))):
 
             with pytest.raises(t.ValidationError) as e:
 
@@ -637,9 +633,7 @@ class TestResourceValidationOnUpdate(object):
 
         mock_upload = MockFieldStorage(invalid_file, "invalid.csv")
 
-        invalid_stream = io.BufferedReader(io.BytesIO(INVALID_CSV.encode('utf8')))
-
-        with mock.patch("io.open", return_value=invalid_stream):
+        with mock.patch("io.open", side_effect=lambda *a, **k: io.BufferedReader(io.BytesIO(INVALID_CSV.encode('utf8')))):
 
             with pytest.raises(t.ValidationError):
 
@@ -663,9 +657,7 @@ class TestResourceValidationOnUpdate(object):
 
         mock_upload = MockFieldStorage(valid_file, "valid.csv")
 
-        valid_stream = io.BufferedReader(io.BytesIO(VALID_CSV.encode('utf8')))
-
-        with mock.patch("io.open", return_value=valid_stream):
+        with mock.patch("io.open", side_effect=lambda *a, **k: io.BufferedReader(io.BytesIO(VALID_CSV.encode('utf8')))):
 
             resource = call_action(
                 "resource_update",


### PR DESCRIPTION
## Summary

Six upload-validation tests intermittently fail in CI with `ValueError: read of closed file` (frictionless `loader.py`). They pass locally but fail on GitHub's runners.

## Root cause

The tests patched `io.open` **globally** with `return_value=<one BufferedReader>`, so every `io.open()` call during validation returned the *same* single-use stream. `Package.validate()` triggers several unrelated `io.open` calls (e.g. chardet's encoding-model file, package-metadata reads) alongside the actual resource read. Whichever consumer runs first reads the shared `BytesIO` stream inside a `with` block and closes it; frictionless's later open of the real resource then gets that already-closed handle → `read of closed file`.

(The CKAN uploader is *not* involved — in CKAN 2.11 it uses builtin `open()`, and in the job tests the upload happens before the patch is active.)

Whether it broke depended on the order those global `io.open` consumers fired, which varies by runner timing — hence green locally, red in CI. The pattern has existed since 2021; it surfaced now after unpinned transitive deps (notably `petl` 1.7.17 → 1.7.19) shifted the timing. Last green CI on `development` was the 2.11 migration merge (Apr 27); it has been failing since.

## Fix

Return a **fresh** stream per call via `side_effect`, so each `io.open()` behaves like a real independent file open. No production code changes — test-only.

Affected tests:
- `test_logic.py`: create/update × pass/fail upload
- `test_jobs.py`: `test_job_local_paths_are_hidden`, `test_job_pass_validation_options_string`